### PR TITLE
Add fast refresh presets and custom timer input

### DIFF
--- a/Chromium/popup.html
+++ b/Chromium/popup.html
@@ -146,6 +146,44 @@
         body.dark-mode .sun-icon {
             display: block;
         }
+        .custom-interval {
+            display: none;
+            margin-top: 10px;
+        }
+        .custom-interval label {
+            margin-bottom: 8px;
+        }
+        .custom-interval input {
+            width: calc(100% - 90px);
+            padding: 8px;
+            margin-right: 10px;
+            border: 1px solid #C2C8CC;
+            border-radius: 4px;
+        }
+        body.dark-mode .custom-interval input {
+            background-color: #2F3941;
+            color: #f5f5f5;
+            border-color: #555;
+        }
+        .custom-interval button {
+            padding: 8px 12px;
+            background-color: #17494D;
+            color: #fff;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+        .custom-interval button:hover {
+            background-color: #0f3235;
+        }
+        .custom-interval .helper {
+            margin-top: 6px;
+            font-size: 12px;
+            color: #666;
+        }
+        body.dark-mode .custom-interval .helper {
+            color: #C2C8CC;
+        }
     </style>
 </head>
 <body>
@@ -177,13 +215,28 @@
     
     <label for="intervalSelect">Refresh interval:</label>
     <select id="intervalSelect">
-        <option value="0.5">30 Seconds</option>
-        <option value="1">1 Minute</option>
-        <option value="2">2 Minutes</option>
-        <option value="3">3 Minutes</option>
-        <option value="5">5 Minutes</option>
-        <option value="10">10 Minutes</option>
+        <option value="5">5 Seconds</option>
+        <option value="10">10 Seconds</option>
+        <option value="15">15 Seconds</option>
+        <option value="20">20 Seconds</option>
+        <option value="25">25 Seconds</option>
+        <option value="30">30 Seconds</option>
+        <option value="60">1 Minute</option>
+        <option value="120">2 Minutes</option>
+        <option value="180">3 Minutes</option>
+        <option value="300">5 Minutes</option>
+        <option value="600">10 Minutes</option>
+        <option value="custom">Custom…</option>
     </select>
+
+    <div id="customInterval" class="custom-interval">
+        <label for="customIntervalInput">Custom interval (seconds):</label>
+        <div style="display: flex; align-items: center;">
+            <input type="number" id="customIntervalInput" min="3" step="1" placeholder="Enter seconds">
+            <button id="customIntervalApply" type="button">Apply</button>
+        </div>
+        <div class="helper">Tip: minimum 3 seconds to avoid overlapping refreshes.</div>
+    </div>
     
     <div id="countdown"></div>
     

--- a/Chromium/popup.js
+++ b/Chromium/popup.js
@@ -13,6 +13,10 @@ document.addEventListener('DOMContentLoaded', () => {
     const refreshToggle = document.getElementById('refreshToggle');
     const versionElement = document.getElementById('extensionVersion');
     const modeToggleIcon = document.getElementById('modeToggleIcon');
+    const customIntervalSection = document.getElementById('customInterval');
+    const customIntervalInput = document.getElementById('customIntervalInput');
+    const customIntervalApply = document.getElementById('customIntervalApply');
+    const quickIntervals = [5, 10, 15, 20, 25, 30, 60, 120, 180, 300, 600];
     let countdownInterval;
   
     // Fetch and display the extension version
@@ -22,7 +26,9 @@ document.addEventListener('DOMContentLoaded', () => {
   
     function initPopup() {
       chrome.storage.local.get(['refreshInterval', 'isRefreshing'], (data) => {
-        intervalSelect.value = data.refreshInterval !== undefined ? data.refreshInterval.toString() : "0.5";
+        const storedInterval = data.refreshInterval !== undefined ? data.refreshInterval : 0.5;
+        const storedSeconds = Math.max(1, Math.round(storedInterval * 60));
+        syncIntervalSelection(storedSeconds);
         refreshToggle.checked = data.isRefreshing !== undefined ? data.isRefreshing : false;
         
         chrome.runtime.sendMessage({ action: "getRefreshState" }, (response) => {
@@ -51,13 +57,17 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   
     intervalSelect.addEventListener('change', () => {
-      const newInterval = parseFloat(intervalSelect.value);
-      chrome.runtime.sendMessage({ 
-        action: "setRefreshInterval", 
-        interval: newInterval 
-      }, () => {
-        updateCountdown();
-      });
+      if (intervalSelect.value === 'custom') {
+        toggleCustomInterval(true);
+        customIntervalInput.focus();
+        return;
+      }
+
+      toggleCustomInterval(false);
+      const newIntervalSeconds = parseInt(intervalSelect.value, 10);
+      if (!Number.isNaN(newIntervalSeconds)) {
+        applyIntervalSeconds(newIntervalSeconds);
+      }
     });
   
     refreshToggle.addEventListener('change', () => {
@@ -70,6 +80,53 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   
     modeToggleIcon.addEventListener('click', toggleDarkMode);
+
+    customIntervalApply.addEventListener('click', () => {
+      const customSeconds = parseInt(customIntervalInput.value, 10);
+      if (Number.isNaN(customSeconds) || customSeconds < 3) {
+        customIntervalInput.setCustomValidity("Please enter at least 3 seconds.");
+        customIntervalInput.reportValidity();
+        return;
+      }
+      customIntervalInput.setCustomValidity("");
+      intervalSelect.value = 'custom';
+      applyIntervalSeconds(customSeconds);
+    });
+
+    customIntervalInput.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        customIntervalApply.click();
+      }
+    });
+
+    function toggleCustomInterval(shouldShow) {
+      customIntervalSection.style.display = shouldShow ? 'block' : 'none';
+    }
+
+    function syncIntervalSelection(storedSeconds) {
+      if (quickIntervals.includes(storedSeconds)) {
+        intervalSelect.value = storedSeconds.toString();
+        toggleCustomInterval(false);
+      } else {
+        intervalSelect.value = 'custom';
+        customIntervalInput.value = storedSeconds;
+        toggleCustomInterval(true);
+      }
+    }
+
+    function applyIntervalSeconds(seconds) {
+      const normalizedSeconds = Math.max(3, Math.floor(seconds));
+      const intervalInMinutes = normalizedSeconds / 60;
+
+      chrome.runtime.sendMessage({ 
+        action: "setRefreshInterval", 
+        interval: intervalInMinutes 
+      }, () => {
+        updateCountdown();
+      });
+      syncIntervalSelection(normalizedSeconds);
+    }
   
     function updateCountdown() {
       clearInterval(countdownInterval);

--- a/Firefox/popup.html
+++ b/Firefox/popup.html
@@ -145,6 +145,44 @@
         body.dark-mode .sun-icon {
             display: block;
         }
+        .custom-interval {
+            display: none;
+            margin-top: 10px;
+        }
+        .custom-interval label {
+            margin-bottom: 8px;
+        }
+        .custom-interval input {
+            width: calc(100% - 90px);
+            padding: 8px;
+            margin-right: 10px;
+            border: 1px solid #C2C8CC;
+            border-radius: 4px;
+        }
+        body.dark-mode .custom-interval input {
+            background-color: #2F3941;
+            color: #f5f5f5;
+            border-color: #555;
+        }
+        .custom-interval button {
+            padding: 8px 12px;
+            background-color: #17494D;
+            color: #fff;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+        .custom-interval button:hover {
+            background-color: #0f3235;
+        }
+        .custom-interval .helper {
+            margin-top: 6px;
+            font-size: 12px;
+            color: #666;
+        }
+        body.dark-mode .custom-interval .helper {
+            color: #C2C8CC;
+        }
     </style>
 </head>
 <body>
@@ -176,13 +214,28 @@
     
     <label for="intervalSelect">Refresh interval:</label>
     <select id="intervalSelect">
-        <option value="0.5">30 Seconds</option>
-        <option value="1">1 Minute</option>
-        <option value="2">2 Minutes</option>
-        <option value="3">3 Minutes</option>
-        <option value="5">5 Minutes</option>
-        <option value="10">10 Minutes</option>
+        <option value="5">5 Seconds</option>
+        <option value="10">10 Seconds</option>
+        <option value="15">15 Seconds</option>
+        <option value="20">20 Seconds</option>
+        <option value="25">25 Seconds</option>
+        <option value="30">30 Seconds</option>
+        <option value="60">1 Minute</option>
+        <option value="120">2 Minutes</option>
+        <option value="180">3 Minutes</option>
+        <option value="300">5 Minutes</option>
+        <option value="600">10 Minutes</option>
+        <option value="custom">Custom…</option>
     </select>
+
+    <div id="customInterval" class="custom-interval">
+        <label for="customIntervalInput">Custom interval (seconds):</label>
+        <div style="display: flex; align-items: center;">
+            <input type="number" id="customIntervalInput" min="3" step="1" placeholder="Enter seconds">
+            <button id="customIntervalApply" type="button">Apply</button>
+        </div>
+        <div class="helper">Tip: minimum 3 seconds to avoid overlapping refreshes.</div>
+    </div>
     
     <div id="countdown"></div>
     

--- a/Firefox/popup.js
+++ b/Firefox/popup.js
@@ -13,6 +13,10 @@ document.addEventListener('DOMContentLoaded', () => {
     const refreshToggle = document.getElementById('refreshToggle');
     const versionElement = document.getElementById('extensionVersion');
     const modeToggleIcon = document.getElementById('modeToggleIcon');
+    const customIntervalSection = document.getElementById('customInterval');
+    const customIntervalInput = document.getElementById('customIntervalInput');
+    const customIntervalApply = document.getElementById('customIntervalApply');
+    const quickIntervals = [5, 10, 15, 20, 25, 30, 60, 120, 180, 300, 600];
     let countdownInterval;
   
     // Fetch and display the extension version
@@ -22,7 +26,9 @@ document.addEventListener('DOMContentLoaded', () => {
   
     function initPopup() {
         browser.storage.sync.get(['refreshInterval', 'isRefreshing']).then((data) => {
-            intervalSelect.value = data.refreshInterval !== undefined ? data.refreshInterval.toString() : "0.5";
+            const storedInterval = data.refreshInterval !== undefined ? data.refreshInterval : 0.5;
+            const storedSeconds = Math.max(1, Math.round(storedInterval * 60));
+            syncIntervalSelection(storedSeconds);
             refreshToggle.checked = data.isRefreshing !== undefined ? data.isRefreshing : false;
             
             browser.runtime.sendMessage({ action: "getRefreshState" }).then((response) => {
@@ -49,13 +55,17 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   
     intervalSelect.addEventListener('change', () => {
-        const newInterval = parseFloat(intervalSelect.value);
-        browser.runtime.sendMessage({ 
-            action: "setRefreshInterval", 
-            interval: newInterval 
-        }).then(() => {
-            updateCountdown();
-        });
+        if (intervalSelect.value === 'custom') {
+            toggleCustomInterval(true);
+            customIntervalInput.focus();
+            return;
+        }
+
+        toggleCustomInterval(false);
+        const newIntervalSeconds = parseInt(intervalSelect.value, 10);
+        if (!Number.isNaN(newIntervalSeconds)) {
+            applyIntervalSeconds(newIntervalSeconds);
+        }
     });
   
     refreshToggle.addEventListener('change', () => {
@@ -74,6 +84,53 @@ document.addEventListener('DOMContentLoaded', () => {
             darkModeInitialized = true;
         }
     });
+
+    customIntervalApply.addEventListener('click', () => {
+        const customSeconds = parseInt(customIntervalInput.value, 10);
+        if (Number.isNaN(customSeconds) || customSeconds < 3) {
+            customIntervalInput.setCustomValidity("Please enter at least 3 seconds.");
+            customIntervalInput.reportValidity();
+            return;
+        }
+        customIntervalInput.setCustomValidity("");
+        intervalSelect.value = 'custom';
+        applyIntervalSeconds(customSeconds);
+    });
+
+    customIntervalInput.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter') {
+            event.preventDefault();
+            customIntervalApply.click();
+        }
+    });
+
+    function toggleCustomInterval(shouldShow) {
+        customIntervalSection.style.display = shouldShow ? 'block' : 'none';
+    }
+
+    function syncIntervalSelection(storedSeconds) {
+        if (quickIntervals.includes(storedSeconds)) {
+            intervalSelect.value = storedSeconds.toString();
+            toggleCustomInterval(false);
+        } else {
+            intervalSelect.value = 'custom';
+            customIntervalInput.value = storedSeconds;
+            toggleCustomInterval(true);
+        }
+    }
+
+    function applyIntervalSeconds(seconds) {
+        const normalizedSeconds = Math.max(3, Math.floor(seconds));
+        const intervalInMinutes = normalizedSeconds / 60;
+
+        browser.runtime.sendMessage({ 
+            action: "setRefreshInterval", 
+            interval: intervalInMinutes 
+        }).then(() => {
+            updateCountdown();
+        });
+        syncIntervalSelection(normalizedSeconds);
+    }
   
     function updateCountdown() {
         clearInterval(countdownInterval);

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Zendesk View Auto-Refresh is a browser extension that automatically refreshes yo
 
 ## Features
 - Automatic refresh of Zendesk views
-- Customizable refresh intervals (30 seconds to 10 minutes)
+- Customizable refresh intervals (as fast as 5 seconds, up to 10 minutes) plus a custom timer field
 - Easy on/off toggle with a live countdown to the next refresh
 - Dark mode toggle that remembers your preference
 - Works across multiple Zendesk tabs simultaneously
@@ -27,7 +27,7 @@ Zendesk View Auto-Refresh is a browser extension that automatically refreshes yo
 ## Usage
 1. Install the extension for your browser.
 2. Click the extension icon to open the popup.
-3. Select your desired refresh interval from the dropdown menu (30 seconds to 10 minutes).
+3. Select your desired refresh interval from the dropdown menu (5 seconds to 10 minutes) or set a custom interval in seconds.
 4. Toggle **Enable auto-refresh** to start or pause refreshing.
 5. (Optional) Tap the moon/sun icon to switch between light and dark mode.
 6. Your settings are saved automatically for future sessions.


### PR DESCRIPTION
## Summary
- add second-level quick interval options and a custom seconds input to the Chromium and Firefox popups
- normalize interval handling in the popups so stored selections sync with countdown updates
- document the faster preset range and custom timer option in the README

## Testing
- not run (UI-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695941eca4b8832dadcd6133f382f9e3)